### PR TITLE
Cleanup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ember-data-github [![Build Status](https://travis-ci.org/jimmay5469/ember-data-github.svg)](https://travis-ci.org/jimmay5469/ember-data-github)
+# ember-data-github [![Build Status](https://travis-ci.org/jimmay5469/ember-data-github.svg)](https://travis-ci.org/jimmay5469/ember-data-github) [![Ember Observer Score](http://emberobserver.com/badges/ember-data-github.svg)](http://emberobserver.com/addons/ember-data-github)
 
 Ember Data library for the [GitHub API](https://developer.github.com/v3/).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ember-data-github [![Build Status](https://travis-ci.org/jimmay5469/ember-data-github.svg)](https://travis-ci.org/jimmay5469/ember-data-github) [![Ember Observer Score](http://emberobserver.com/badges/ember-data-github.svg)](http://emberobserver.com/addons/ember-data-github)
+# ember-data-github [![Build Status](https://travis-ci.org/jimmay5469/ember-data-github.svg?branch=master)](https://travis-ci.org/jimmay5469/ember-data-github) [![Ember Observer Score](http://emberobserver.com/badges/ember-data-github.svg)](http://emberobserver.com/addons/ember-data-github)
 
 Ember Data library for the [GitHub API](https://developer.github.com/v3/).
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,22 @@ Ember Data library for the [GitHub API](https://developer.github.com/v3/).
 
 ## Using ember-data-github
 
+**Note:** this is currently under active development so use at your own risk until the version is above 0.0.0.
+
 ```
 ember install ember-data-github
 ```
 
-To use OAuth endpoints you must also make sure you have a session service which contains a property named `githubAccessToken`.
+To use OAuth endpoints you must also make sure you have a session service which contains a property named `githubAccessToken` with the currently logged in user's GitHub access token (Exmple: [app/services/session.js](https://github.com/jimmay5469/old-hash/blob/master/app/services/session.js)).
 
 To see what is currently supported check out the `addon/models/` directory.  Currently this addon does not support write actions.
+
+Examples:
+```
+this.get('store').find('githubUser', ''); // get the current user
+this.get('store').find('githubUser', 'jimmay5469'); // get a user
+this.get('store').find('githubRepository', 'jimmay5469/old-hash'); // get a repository
+```
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Ember Data library for the [GitHub API](https://developer.github.com/v3/).
 ember install ember-data-github
 ```
 
-To use OAuth endpoints you must also make sure you have a session service which contains a property named `githubToken`.
+To use OAuth endpoints you must also make sure you have a session service which contains a property named `githubAccessToken`.
 
 To see what is currently supported check out the `addon/models/` directory.  Currently this addon does not support write actions.
 

--- a/addon/adapters/github.js
+++ b/addon/adapters/github.js
@@ -4,9 +4,9 @@ import Ember from 'ember';
 export default DS.RESTAdapter.extend({
   session: Ember.inject.service(),
   host: 'https://api.github.com',
-  headers: Ember.computed('session.githubToken', function() {
+  headers: Ember.computed('session.githubAccessToken', function() {
     return {
-      Authorization: `token ${this.get('session.githubToken')}`,
+      Authorization: `token ${this.get('session.githubAccessToken')}`,
     };
   }),
   pathForType: function(type) {


### PR DESCRIPTION
Rename `githubToken` to `githubAccessToken` to avoid any possible confusion and add a few examples to the README.