### PR TITLE
Prevent extra records in the store because of id casing

### DIFF
--- a/addon/serializers/github-repository.js
+++ b/addon/serializers/github-repository.js
@@ -3,7 +3,7 @@ import GithubSerializer from './github';
 export default GithubSerializer.extend({
   normalize: function(type, hash, prop) {
     hash = {
-      id: hash.full_name,
+      id: hash.recordId || hash.full_name,
       fullName: hash.full_name,
       name: hash.name
     };

--- a/addon/serializers/github-user.js
+++ b/addon/serializers/github-user.js
@@ -3,14 +3,13 @@ import GithubSerializer from './github';
 export default GithubSerializer.extend({
   extractSingle: function(store, primaryType, payload, recordId) {
     if(recordId==='#') {
-      payload.isCurrent = true;
       payload.repos_url = payload.repos_url.replace(`users/${payload.login}`, 'user');
     }
     return this._super(store, primaryType, payload, recordId);
   },
   normalize: function(type, hash, prop) {
     hash = {
-      id: hash.isCurrent ? '#' : hash.login,
+      id: hash.recordId || hash.login,
       login: hash.login,
       name: hash.name,
       avatarUrl: hash.avatar_url,

--- a/addon/serializers/github.js
+++ b/addon/serializers/github.js
@@ -8,6 +8,7 @@ export default DS.RESTSerializer.extend({
     return this._super(store, primaryType, wrappedPayload);
   },
   extractSingle: function(store, primaryType, payload, recordId) {
+    payload.recordId = recordId;
     var wrappedPayload = {};
     wrappedPayload[primaryType.typeKey] = payload;
     return this._super(store, primaryType, wrappedPayload, recordId);

--- a/tests/acceptance/github-repository-test.js
+++ b/tests/acceptance/github-repository-test.js
@@ -22,15 +22,16 @@ module('github-repository', {
 });
 
 test('finding a repository without authorization', function(assert) {
-  assert.expect(5);
+  assert.expect(6);
 
-  server.get('/repos/user1/repository1', function(request) {
+  server.get('/repos/User1/Repository1', function(request) {
     return [200, {}, Factory.build('repository')];
   });
 
   return Ember.run(function () {
-    return store.find('githubRepository', 'user1/repository1').then(function(repository) {
+    return store.find('githubRepository', 'User1/Repository1').then(function(repository) {
       assertGithubRepositoryOk(assert, repository);
+      assert.equal(store.all('githubRepository').get('length'), 1);
       assert.equal(server.handledRequests.length, 1);
       assert.equal(server.handledRequests[0].requestHeaders.Authorization, undefined);
     });
@@ -38,7 +39,7 @@ test('finding a repository without authorization', function(assert) {
 });
 
 test('finding a repository', function(assert) {
-  assert.expect(5);
+  assert.expect(6);
 
   container.lookup('service:session').set('githubAccessToken', 'abc123');
   server.get('/repos/user1/repository1', function(request) {
@@ -48,6 +49,7 @@ test('finding a repository', function(assert) {
   return Ember.run(function () {
     return store.find('githubRepository', 'user1/repository1').then(function(repository) {
       assertGithubRepositoryOk(assert, repository);
+      assert.equal(store.all('githubRepository').get('length'), 1);
       assert.equal(server.handledRequests.length, 1);
       assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123');
     });

--- a/tests/acceptance/github-user-test.js
+++ b/tests/acceptance/github-user-test.js
@@ -22,15 +22,16 @@ module('github-user', {
 });
 
 test('finding a user without authorization', function(assert) {
-  assert.expect(6);
+  assert.expect(7);
 
-  server.get('/users/user1', function(request) {
+  server.get('/users/User1', function(request) {
     return [200, {}, Factory.build('user')];
   });
 
   return Ember.run(function () {
-    return store.find('githubUser', 'user1').then(function(user) {
+    return store.find('githubUser', 'User1').then(function(user) {
       assertGithubUserOk(assert, user);
+      assert.equal(store.all('githubUser').get('length'), 1);
       assert.equal(server.handledRequests.length, 1);
       assert.equal(server.handledRequests[0].requestHeaders.Authorization, undefined);
     });
@@ -38,7 +39,7 @@ test('finding a user without authorization', function(assert) {
 });
 
 test('finding a user', function(assert) {
-  assert.expect(6);
+  assert.expect(7);
 
   container.lookup('service:session').set('githubAccessToken', 'abc123');
   server.get('/users/user1', function(request) {
@@ -48,6 +49,7 @@ test('finding a user', function(assert) {
   return Ember.run(function () {
     return store.find('githubUser', 'user1').then(function(user) {
       assertGithubUserOk(assert, user);
+      assert.equal(store.all('githubUser').get('length'), 1);
       assert.equal(server.handledRequests.length, 1);
       assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123');
     });


### PR DESCRIPTION
`this.get('store').find('githubUser', 'JiMmAy5469')` ends up inserting two records into the store, one with the requested casing on the id (JiMmAy5469), and one with the correct casing returned from GitHub (jimmay5469).  This may end up causing problems and should be addressed.