### PR TITLE
Add repository owner relationship

### DIFF
--- a/addon/models/github-repository.js
+++ b/addon/models/github-repository.js
@@ -2,5 +2,6 @@ import DS from 'ember-data';
 
 export default DS.Model.extend({
   fullName: DS.attr('string'),
-  name: DS.attr('string')
+  name: DS.attr('string'),
+  owner: DS.belongsTo('githubUser', { async: true })
 });

--- a/addon/serializers/github-repository.js
+++ b/addon/serializers/github-repository.js
@@ -5,7 +5,10 @@ export default GithubSerializer.extend({
     hash = {
       id: hash.recordId || hash.full_name,
       fullName: hash.full_name,
-      name: hash.name
+      name: hash.name,
+      links: {
+        owner: hash.owner.url
+      }
     };
     return this._super(type, hash, prop);
   }

--- a/tests/acceptance/github-repository-test.js
+++ b/tests/acceptance/github-repository-test.js
@@ -77,3 +77,25 @@ test('finding all repositories', function(assert) {
     });
   });
 });
+
+test('getting a repository\'s owner', function(assert) {
+  assert.expect(7);
+
+  container.lookup('service:session').set('githubAccessToken', 'abc123');
+  server.get('/repos/user1/repository1', function(request) {
+    return [200, {}, Factory.build('repository')];
+  });
+  server.get('/users/user1', function(request) {
+    return [200, {}, Factory.build('user')];
+  });
+
+  return Ember.run(function () {
+    return store.find('githubRepository', 'user1/repository1').then(function(repository) {
+      return repository.get('owner').then(function(owner) {
+        assertGithubUserOk(assert, owner);
+        assert.equal(server.handledRequests.length, 2);
+        assert.equal(server.handledRequests[0].requestHeaders.Authorization, 'token abc123');
+      });
+    });
+  });
+});

--- a/tests/helpers/factories/repository.js
+++ b/tests/helpers/factories/repository.js
@@ -3,6 +3,7 @@ export default {
     Factory.define('repository')
       .sequence('id')
       .sequence('name', function(i) { return `repository${i}`; })
-      .sequence('full_name', function(i) { return `user1/repository${i}`; });
+      .sequence('full_name', function(i) { return `user1/repository${i}`; })
+      .attr('owner', { url: 'https://api.github.com/users/user1' });
   }
 };

--- a/tests/unit/models/github-organization-test.js
+++ b/tests/unit/models/github-organization-test.js
@@ -6,7 +6,8 @@ import {
 moduleForModel('github-organization', {
   // Specify the other units that are required for this test.
   needs: [
-    'model:githubRepository'
+    'model:githubRepository',
+    'model:githubUser'
   ]
 });
 

--- a/tests/unit/models/github-repository-test.js
+++ b/tests/unit/models/github-repository-test.js
@@ -5,7 +5,9 @@ import {
 
 moduleForModel('github-repository', {
   // Specify the other units that are required for this test.
-  needs: []
+  needs: [
+    'model:githubUser'
+  ]
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/serializers/github-organization-test.js
+++ b/tests/unit/serializers/github-organization-test.js
@@ -7,7 +7,8 @@ moduleForModel('github-organization', {
   // Specify the other units that are required for this test.
   needs: [
     'serializer:github-organization',
-    'model:githubRepository'
+    'model:githubRepository',
+    'model:githubUser'
   ]
 });
 

--- a/tests/unit/serializers/github-repository-test.js
+++ b/tests/unit/serializers/github-repository-test.js
@@ -5,7 +5,10 @@ import {
 
 moduleForModel('github-repository', {
   // Specify the other units that are required for this test.
-  needs: ['serializer:github-repository']
+  needs: [
+    'serializer:github-repository',
+    'model:githubUser'
+  ]
 });
 
 // Replace this with your real tests.


### PR DESCRIPTION
Not all of the user properties are included in the embedded owner object so I went with an async relationship and require a network hit in order to get the full user object.